### PR TITLE
Upgrade ember-cli-htmlbars to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   ],
   "dependencies": {
     "emberx-select": "^2.0.1",
-    "ember-cli-htmlbars": "0.7.9",
+    "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-babel": "^5.0.0"
   },
   "ember-addon": {


### PR DESCRIPTION
Current version will break app build on windows  once  broccolijs/broccoli-merge-trees#31 is merged
Upgrade ember-cli-htmlbars to latest version fixed the issue 

cc @stefanpenner 
