### PR TITLE
Lock down dependency on emberx-select

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-addon"
   ],
   "dependencies": {
-    "emberx-select": "^2.0.1",
+    "emberx-select": "2.0.1",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-babel": "^5.0.0"
   },


### PR DESCRIPTION
Remove caret on emberx-select dependency

emberx-select removed placeholder in https://github.com/thefrontside/emberx-select/pull/86
