### PR TITLE
Unbreak anything using x-select 2.1+

### DIFF
--- a/addon/components/x-select-blockless.js
+++ b/addon/components/x-select-blockless.js
@@ -21,6 +21,22 @@ export default XSelectComponent.extend({
   }),
 
   /**
+   * Alias to `value`.
+   * This way we accept `value` or `selection` properties.
+   *
+   * @property selection
+   */
+  selection: Ember.computed.alias('value'),
+
+  /**
+   * Alias to `prompt`.
+   * This way we accept `prompt` or `placeholder` properties.
+   *
+   * @property placeholder
+   */
+  placeholder: Ember.computed.alias('prompt'),
+
+  /**
    * Auxiliary computed property that replaces `content.`
    * in `optionLabelPath`.
    *

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "emberx-select",
   "dependencies": {
-    "ember": "1.13.4",
+    "ember": "^1.13.4",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-mocha": "0.8.1",

--- a/bower.json
+++ b/bower.json
@@ -8,7 +8,7 @@
     "chai-jquery": "~2.0.0",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.1",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.0"
   }
 }

--- a/tests/acceptance/shared/attr-test.js
+++ b/tests/acceptance/shared/attr-test.js
@@ -1,5 +1,4 @@
 /*global expect */
-/*global it */
 import { beforeEach, describe } from '../../test-helper';
 import { it } from 'ember-mocha';
 


### PR DESCRIPTION
We removed old code from x-select proper that the blockless form was
relying on. This adds the code into x-select-blockless
